### PR TITLE
Redirect to Replicate instead of iframe

### DIFF
--- a/generic/index.html
+++ b/generic/index.html
@@ -20,6 +20,9 @@
   <meta name="twitter:description" content="Pixray with custom settings" />
   <meta name="twitter:image" content="https://pixray.gob.io/generic/preview-image.png" />
 
+  <meta http-equiv="refresh" content="0; URL=https://replicate.com/dribnet/pixray">
+  <link rel="canonical" href="https://replicate.com/dribnet/pixray">
+
   <title>pixray</title>
 
 <body style="background-color:white">
@@ -27,7 +30,8 @@
 
     <h2>pixray</h2>
 
-    <iframe src="https://replicate.com/dribnet/pixray/embed" frameborder="0" scrolling="no" height="800" width="1000"></iframe>
+    <a href="https://replicate.com/dribnet/pixray">Now on Replicate.</a> Redirecting...
+
 
 <br>
 See <a href="https://twitter.com/pixray">@pixray posts</a> or <a href="https://github.com/pixray/pixray">join the project<a>

--- a/genesis/index.html
+++ b/genesis/index.html
@@ -20,6 +20,10 @@
   <meta name="twitter:description" content="Mint images straight to Tezos" />
   <meta name="twitter:image" content="https://pixray.gob.io/genesis/preview-image.png" />
 
+  <meta http-equiv="refresh" content="0; URL=https://replicate.com/dribnet/pixray-genesis">
+  <link rel="canonical" href="https://replicate.com/dribnet/pixray-genesis">
+
+
 <!--    <script
     type="module"
     src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"
@@ -174,7 +178,7 @@ Have fun and good luck. 🤗
         </div>
     </div>
 
-    <iframe src="https://replicate.com/dribnet/pixray-genesis/embed" frameborder="0" scrolling="no" height="700" width="100%"></iframe>
+    <a href="https://replicate.com/dribnet/pixray-genesis">Now on Replicate.</a> Redirecting...
 
     <!-- <h4>result</h4> -->
 

--- a/index.html
+++ b/index.html
@@ -30,13 +30,13 @@
 
 <a href="https://replicate.com/pixray/text2image"><img width="100%" src="previews/text2image.png"><a><p>
 
-<a href="text2pixel/"><img width="100%" src="previews/2021-11-23-Gob.io-pixray_text2pixel.png"><a><p>
+<a href="https://replicate.com/dribnet/pixray-text2pixel"><img width="100%" src="previews/2021-11-23-Gob.io-pixray_text2pixel.png"><a><p>
 
-<a href="genesis/"><img width="100%" src="previews/genesis.png"><a><p>
+<a href="https://replicate.com/dribnet/pixray-genesis"><img width="100%" src="previews/genesis.png"><a><p>
 
-<a href="tiler/"><img width="100%" src="previews/tiler.png"><a><p>
+<a href="https://replicate.com/dribnet/pixray-tiler"><img width="100%" src="previews/tiler.png"><a><p>
 
-<a href="generic/"><img width="100%" src="previews/2021-11-23-Gob.io-pixray_generic.png"><a><p>
+<a href="https://replicate.com/dribnet/pixray"><img width="100%" src="previews/2021-11-23-Gob.io-pixray_generic.png"><a><p>
 
 <br>
 See <a href="https://twitter.com/pixray">@pixray posts</a> or <a href="https://github.com/pixray/pixray">join the project<a>

--- a/text2image/index.html
+++ b/text2image/index.html
@@ -20,6 +20,9 @@
   <meta name="twitter:description" content="Turn any description into an image" />
   <meta name="twitter:image" content="https://pixray.gob.io/text2image/preview-image.png" />
 
+  <meta http-equiv="refresh" content="0; URL=https://replicate.com/dribnet/pixray-text2image">
+  <link rel="canonical" href="https://replicate.com/dribnet/pixray-text2image">
+
   <title>pixray text2image</title>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -39,7 +42,7 @@
 </h3></center>
 
 <body style="background-color:white">
-    <iframe src="https://replicate.com/dribnet/pixray-text2image/embed" frameborder="0" scrolling="no" height="700" width="1000"></iframe>
+    <a href="https://replicate.com/dribnet/pixray-text2image">Now on Replicate.</a> Redirecting...
 
 <br>
 See <a href="https://twitter.com/pixray">@pixray posts</a> or <a href="https://github.com/pixray/pixray">join the project<a>

--- a/text2pixel/index.html
+++ b/text2pixel/index.html
@@ -20,10 +20,13 @@
   <meta name="twitter:description" content="Turn any description into pixel art" />
   <meta name="twitter:image" content="https://pixray.gob.io/text2pixel/preview-image.png" />
 
+  <meta http-equiv="refresh" content="0; URL=https://replicate.com/dribnet/pixray-text2pixel">
+  <link rel="canonical" href="https://replicate.com/dribnet/pixray-text2pixel">
+
   <title>pixray text2pixel</title>
 
 <body style="background-color:white">
-    <iframe src="https://replicate.com/dribnet/pixray-text2pixel/embed" frameborder="0" scrolling="no" height="640" width="1000"></iframe>
+    <a href="https://replicate.com/dribnet/pixray-text2pixel">Now on Replicate.</a> Redirecting...
 
 <br>
 See <a href="https://twitter.com/pixray">@pixray posts</a> or <a href="https://github.com/pixray/pixray">join the project<a>

--- a/tiler/index.html
+++ b/tiler/index.html
@@ -20,6 +20,9 @@
   <meta name="twitter:description" content="Turn any description into wallpaper tiles" />
   <meta name="twitter:image" content="https://pixray.gob.io/tiler/preview-image.png" />
 
+  <meta http-equiv="refresh" content="0; URL=https://replicate.com/dribnet/pixray-tiler">
+  <link rel="canonical" href="https://replicate.com/dribnet/pixray-tiler">
+
   <title>pixray tiler</title>
   <style>
   body {
@@ -46,7 +49,7 @@ window.addEventListener("message", (event) => {
 
 <!-- <body style="background-color:white"> -->
 <body style="background-color:white;">
-    <iframe src="https://replicate.com/dribnet/pixray-tiler/embed" frameborder="0" scrolling="no" height="700" width="1000"></iframe>
+    <a href="https://replicate.com/dribnet/pixray-tiler">Now on Replicate.</a> Redirecting...
 
 <br>
 See <a href="https://twitter.com/pixray">@pixray posts</a> or <a href="https://github.com/pixray/pixray">join the project<a>


### PR DESCRIPTION
I have also updated some of the descriptions / readmes on Replicate to
reflect the content that was on these pages.

The only one that's a bit weird is the genesis model, which doesn't
actually do what it says it does any longer, so I have just left that
one blank.
